### PR TITLE
Feature/fix redis grain storage errors after redis server reboot

### DIFF
--- a/src/Orleans.Persistence.Redis/RedisGrainStorage.cs
+++ b/src/Orleans.Persistence.Redis/RedisGrainStorage.cs
@@ -9,8 +9,8 @@ using Orleans.Configuration;
 using Orleans.Persistence.Redis;
 using Orleans.Persistence.Redis.Serialization;
 using Orleans.Runtime;
-using StackExchange.Redis;
 using Orleans.Storage;
+using StackExchange.Redis;
 using static System.FormattableString;
 
 namespace Orleans.Persistence
@@ -21,6 +21,7 @@ namespace Orleans.Persistence
     public class RedisGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
     {
         private const string WriteScript = "local etag = redis.call('HGET', KEYS[1], 'etag')\nif etag == false or etag == ARGV[1] then return redis.call('HMSET', KEYS[1], 'etag', ARGV[2], 'data', ARGV[3]) else return false end";
+        private const int ReloadWriteScriptMaxCount = 3;
 
         private readonly string _serviceId;
         private readonly string _name;
@@ -85,17 +86,7 @@ namespace Orleans.Persistence
                 }
 
                 _preparedWriteScript = LuaScript.Prepare(WriteScript);
-
-                var loadTasks = new Task<LoadedLuaScript>[_redisOptions.EndPoints.Count];
-                for (int i = 0; i < _redisOptions.EndPoints.Count; i++)
-                {
-                    var endpoint = _redisOptions.EndPoints.ElementAt(i);
-                    var server = _connection.GetServer(endpoint);
-
-                    loadTasks[i] = _preparedWriteScript.LoadAsync(server);
-                }
-                await Task.WhenAll(loadTasks);
-                _preparedWriteScriptHash = loadTasks.First().Result.Hash;
+                _preparedWriteScriptHash = await LoadWriteScriptAsync().ConfigureAwait(false);
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
@@ -111,6 +102,23 @@ namespace Orleans.Persistence
                     _name, _serviceId, timer.Elapsed.TotalMilliseconds.ToString("0.00"), ex.Message);
                 throw ex;
             }
+        }
+
+        private async Task<byte[]> LoadWriteScriptAsync()
+        {
+            Debug.Assert(_connection is not null);
+            Debug.Assert(_preparedWriteScript is not null);
+
+            var loadTasks = new Task<LoadedLuaScript>[_redisOptions.EndPoints.Count];
+            for (int i = 0; i < _redisOptions.EndPoints.Count; i++)
+            {
+                var endpoint = _redisOptions.EndPoints.ElementAt(i);
+                var server = _connection.GetServer(endpoint);
+
+                loadTasks[i] = _preparedWriteScript.LoadAsync(server);
+            }
+            await Task.WhenAll(loadTasks).ConfigureAwait(false);
+            return loadTasks.First().Result.Hash;
         }
 
         /// <inheritdoc />
@@ -135,8 +143,9 @@ namespace Orleans.Persistence
                     grainState.ETag = Guid.NewGuid().ToString();
                 }
             }
-            catch (RedisServerException)
+            catch (RedisServerException rse) when (rse.Message is not null && rse.Message.StartsWith("WRONGTYPE ", StringComparison.Ordinal))
             {
+                // HGETALL returned error 'WRONGTYPE Operation against a key holding the wrong kind of value'
                 _logger.LogInformation("Encountered old format grain state for grain of type {GrainType} with id {GrainReference} when reading hash state for key {Key}. Attempting to migrate.",
                     grainType,
                     grainReference,
@@ -150,17 +159,11 @@ namespace Orleans.Persistence
                     grainState.State = _serializer.DeserializeObject(grainState.State.GetType(), simpleKeyValue);
                 }
 
-                var tx = _db.CreateTransaction();
-
                 // ETag does not exist in the storage so create a new one.
-                grainState.ETag = Guid.NewGuid().ToString();
-                
-                // To allow WriteStateAsync to operate at all in these cases the original simple key must be deleted and a hash must be created in its place with the etag that was just assigned.
-                // The original key must be deleted first because a hash cannot overwrite a simple key.
-                // This will create a situation where if the delete succeeds and the HashSet fails the storage does not have the data before the grain state is again written.
-                _ = tx.KeyDeleteAsync(key);
-                _ = tx.HashSetAsync(key, new[] { new HashEntry("etag", grainState.ETag), new HashEntry("data", simpleKeyValue) });
-                if (!await tx.ExecuteAsync().ConfigureAwait(false))
+                var etag = Guid.NewGuid().ToString();
+                grainState.ETag = etag;
+
+                if (!await MigrateAsync(key, etag, simpleKeyValue).ConfigureAwait(false))
                 {
                     _logger.LogError(
                         "Unexpected error while migrating grain state to new storage for grain of type {GrainType} with id {GrainId} and storage key {Key}. Will retry on next operation.",
@@ -181,27 +184,30 @@ namespace Orleans.Persistence
         /// <inheritdoc />
         public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
         {
+            var etag = grainState.ETag ?? "null";
             var key = GetKey(grainReference);
             var newEtag = Guid.NewGuid().ToString();
 
-            RedisResult response;
+            RedisValue payload = default;
+            RedisResult writeWithScriptResponse = null;
             try
             {
-                response = await WriteToRedisAsync(_db, grainState.State, grainState.ETag ?? "null", key, newEtag)
+                payload = _serializer.SerializeObject(grainState.State);
+                writeWithScriptResponse = await WriteToRedisUsingPreparedScriptAsync(payload,
+                        etag: etag,
+                        key: key,
+                        newEtag: newEtag)
                     .ConfigureAwait(false);
             }
-            catch (RedisServerException)
+            catch (RedisServerException rse) when (rse.Message is not null && rse.Message.Contains(" WRONGTYPE ")) // ordinal comparison
             {
+                // EVALSHA returned error like 'ERR Error running script (call to f_4ebd809f882ff80026566f2d7dc8674009a3d14d): @user_script:1: WRONGTYPE Operation against a key holding the wrong kind of value'
                 _logger.LogInformation("Encountered old format grain state for grain of type {GrainType} with id {GrainReference} when writing hash state for key {Key}. Attempting to migrate.",
                     grainType,
                     grainReference,
                     key);
 
-                var tx = _db.CreateTransaction();
-                _ = tx.KeyDeleteAsync(key);
-                var writeTask = WriteToRedisAsync(tx, grainState.State, grainState.ETag ?? "null", key, newEtag).ConfigureAwait(false);
-
-                if (!await tx.ExecuteAsync())
+                if (!await MigrateAsync(key, newEtag, payload).ConfigureAwait(false))
                 {
                     _logger.LogError(
                         "Failed to write grain state for {GrainType} grain with id {GrainReference} with storage key {Key} while migrating to new structure",
@@ -210,8 +216,6 @@ namespace Orleans.Persistence
                         key);
                     throw new RedisStorageException(Invariant($"Failed to write grain state for {grainType} grain with id {grainReference} with storage key {key} while migrating to new structure"));
                 }
-
-                response = await writeTask;
             }
             catch (Exception e)
             {
@@ -224,7 +228,7 @@ namespace Orleans.Persistence
                     e);
             }
 
-            if (response.IsNull)
+            if (writeWithScriptResponse is not null && writeWithScriptResponse.IsNull)
             {
                 throw new InconsistentStateException($"ETag mismatch - tried with ETag: {grainState.ETag}");
             }
@@ -232,12 +236,46 @@ namespace Orleans.Persistence
             grainState.ETag = newEtag;
         }
 
-        private async Task<RedisResult> WriteToRedisAsync(IDatabaseAsync db, object state, string etag, string key, string newEtag)
+        private async Task<bool> MigrateAsync(string key, string etag, RedisValue payload)
         {
-            var payload = _serializer.SerializeObject(state);
+            var tx = _db.CreateTransaction();
 
+            // To allow WriteStateAsync to operate at all in these cases the original simple key must be deleted and a hash must be created in its place with the etag that was just assigned.
+            // The original key must be deleted first because a hash cannot overwrite a simple key.
+            // This will create a situation where if the delete succeeds and the HashSet fails the storage does not have the data before the grain state is again written.
+            _ = tx.KeyDeleteAsync(key);
+            _ = tx.HashSetAsync(key, new[] { new HashEntry("etag", etag), new HashEntry("data", payload) });
+            return await tx.ExecuteAsync().ConfigureAwait(false);
+        }
+
+        private Task<RedisResult> WriteToRedisUsingPreparedScriptAsync(RedisValue payload, string etag, string key, string newEtag)
+        {
+            var keys = new RedisKey[] { key };
             var args = new RedisValue[] { etag, newEtag, payload };
-            return await db.ScriptEvaluateAsync(_preparedWriteScriptHash, new RedisKey[] { key }, args).ConfigureAwait(false);
+            return WriteToRedisUsingPreparedScriptAsync(attemptNum: 0);
+
+
+            async Task<RedisResult> WriteToRedisUsingPreparedScriptAsync(int attemptNum)
+            {
+                try
+                {
+                    return await _db.ScriptEvaluateAsync(_preparedWriteScriptHash, keys, args).ConfigureAwait(false);
+                }
+                catch (RedisServerException rse) when (rse.Message is not null && rse.Message.StartsWith("NOSCRIPT ", StringComparison.Ordinal))
+                {
+                    // EVALSHA returned error 'NOSCRIPT No matching script. Please use EVAL.'.
+                    // This means that SHA1 cache of Lua scripts is cleared at server side, possibly because of Redis server rebooted after Init() method was called. Need to reload Lua script.
+                    // Several attempts are made just in case (e.g. if Redis server is rebooted right after previous script reload).
+                    if (attemptNum >= ReloadWriteScriptMaxCount)
+                    {
+                        throw;
+                    }
+
+                    await LoadWriteScriptAsync().ConfigureAwait(false);
+                    return await WriteToRedisUsingPreparedScriptAsync(attemptNum: attemptNum + 1)
+                        .ConfigureAwait(false);
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Persistence.Redis/RedisGrainStorage.cs
+++ b/src/Orleans.Persistence.Redis/RedisGrainStorage.cs
@@ -108,6 +108,7 @@ namespace Orleans.Persistence
         {
             Debug.Assert(_connection is not null);
             Debug.Assert(_preparedWriteScript is not null);
+            Debug.Assert(_redisOptions.EndPoints.Count > 0);
 
             var loadTasks = new Task<LoadedLuaScript>[_redisOptions.EndPoints.Count];
             for (int i = 0; i < _redisOptions.EndPoints.Count; i++)
@@ -118,7 +119,7 @@ namespace Orleans.Persistence
                 loadTasks[i] = _preparedWriteScript.LoadAsync(server);
             }
             await Task.WhenAll(loadTasks).ConfigureAwait(false);
-            return loadTasks.First().Result.Hash;
+            return loadTasks[0].Result.Hash;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #19.

1. ReadState: perform grain state format migration only when specific kind of RedisServerExceptions occurs (WRONGTYPE).
2. WriteState: handle NOSCRIPT errors related with cleared Redis server script cache (e.g. when Redis is rebooted).
3. WriteState: fix grain state format migration logic - migrate only when specific kind of RedisServerExceptions occurs (WRONGTYPE), unify migration logic with ReadState migration.

Tested on Windows with latest Redis docker image (version 6.2.6).
Test methodology:

1. Automated - existing tests passed.
2. Automated - added new tests with clear of Redis scripts cache before grain state write (passed).
3. Semi-manual using existing test - passed:
- placed breakpoint in `Json_BackwardsCompatible_ETag_Writes` test before last call to `await grain.Set()`
- started debugging of the test
- hit breakpoint
- restarted Redis (with `docker stop` & `docker start` commands)
- checked current value of grain state in Redis (`HGETALL "GrainReference=00000000000000000000000000bc628f03ffffffaf52472e|json"`), compared it with expected value from test
- checked that Redis script cache is empty
- proceeded with test code execution (no errors occured)
- checked current value of grain state in Redis again, compared it with expected value from test and with previously observed value

I am also planning to perform fully-manual test by creating simple silo & client apps and restarting Redis server in between grain state writes.