### PR TITLE
Add custom serializers support

### DIFF
--- a/src/Orleans.Persistence.Redis/RedisGrainStorageFactory.cs
+++ b/src/Orleans.Persistence.Redis/RedisGrainStorageFactory.cs
@@ -20,20 +20,23 @@ namespace Orleans.Persistence
         {
             IOptionsMonitor<RedisStorageOptions> options = services.GetRequiredService<IOptionsMonitor<RedisStorageOptions>>();
 
-            IRedisDataSerializer serializer;
+            IRedisDataSerializer serializer = services.GetService<IRedisDataSerializer>();
             var redisStorageOptions = options.Get(name);
-            if (redisStorageOptions.UseJson)
-            {
-                serializer =  new NewtonsoftJsonRedisDataSerializer(services.GetService<ITypeResolver>(),
-                    services.GetService<IGrainFactory>(), redisStorageOptions.ConfigureJsonSerializerSettings);
-            }
-            else
-            {
-                serializer =  new SerializationManagerRedisDataSerializer(services.GetService<SerializationManager>());
-            }
-            
 
-            
+            if (serializer == null)
+            {
+                if (redisStorageOptions.UseJson)
+                {
+                    serializer =  new NewtonsoftJsonRedisDataSerializer(services.GetService<ITypeResolver>(),
+                        services.GetService<IGrainFactory>(), redisStorageOptions.ConfigureJsonSerializerSettings);
+                }
+                else
+                {
+                    serializer =  new SerializationManagerRedisDataSerializer(services.GetService<SerializationManager>());
+                }
+            }
+
+
             return ActivatorUtilities.CreateInstance<RedisGrainStorage>(services, serializer, redisStorageOptions, name);
         }
     }

--- a/src/Orleans.Persistence.Redis/RedisPersistenceHostingExtensions.cs
+++ b/src/Orleans.Persistence.Redis/RedisPersistenceHostingExtensions.cs
@@ -84,6 +84,18 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
+        /// Add custom redis serializer
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static ISiloBuilder AddRedisGrainStorageSerializer<T>(this ISiloBuilder builder)
+            where T : class, IRedisDataSerializer
+        {
+            return builder.ConfigureServices(services => services.AddTransient<IRedisDataSerializer, T>());
+        }
+
+        /// <summary>
         /// Adds a Redis grain storage provider as the default provider
         /// </summary>
         public static IServiceCollection AddRedisGrainStorageAsDefault(this IServiceCollection services, Action<RedisStorageOptions> configureOptions)

--- a/src/Orleans.Persistence.Redis/Serialization/SystemTextJsonRedisDataSerializer.cs
+++ b/src/Orleans.Persistence.Redis/Serialization/SystemTextJsonRedisDataSerializer.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using StackExchange.Redis;
+
+namespace Orleans.Persistence.Redis.Serialization
+{
+    public class SystemTextJsonRedisDataSerializerOptions {
+        public JsonSerializerOptions JsonOptions { get; set; }
+    }
+    
+    public class SystemTextJsonRedisDataSerializer : IRedisDataSerializer
+    {
+        SystemTextJsonRedisDataSerializerOptions _options;
+        
+        public SystemTextJsonRedisDataSerializer(IServiceProvider serviceProvider)
+        {
+            _options = serviceProvider.GetService<SystemTextJsonRedisDataSerializerOptions>();
+        }
+        
+        public string FormatSpecifier { get; } = "sjson";
+        public RedisValue SerializeObject(object item)
+        {
+            return JsonSerializer.SerializeToUtf8Bytes(item, item.GetType(), _options?.JsonOptions);
+        }
+
+        public object DeserializeObject(Type type, RedisValue serializedValue)
+        {
+            return JsonSerializer.Deserialize(serializedValue, type, _options?.JsonOptions);
+        }
+    }
+
+    public static class SystemTextJsonRedisDataSerializerExtension
+    {
+        /// <summary>
+        /// Use system text json serializer
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static ISiloBuilder AddRedisGrainStorageJsonSerializer(this ISiloBuilder builder, JsonSerializerOptions options = null)
+        {
+            if (options != null)
+            {
+                builder.ConfigureServices(s =>
+                {
+                    s.AddSingleton(new SystemTextJsonRedisDataSerializerOptions()
+                    {
+                        JsonOptions = options
+                    });
+                });
+            }
+
+            builder.AddRedisGrainStorageSerializer<SystemTextJsonRedisDataSerializer>();
+
+            return builder;
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
Right now, the repository has only 2 types of serializers. They both are hardcoded, which makes it impossible to use custom serializers.

I am attaching a proposal on how to add dependency injection support for custom serializers without breaking changes.

I have added System.Text.Json serializer. To enable it you need to add it to SiloBuilder
```
siloBuilder.AddRedisGrainStorageJsonSerializer();
```